### PR TITLE
Stop stream even when then component is unloaded before preview is shown

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -120,6 +120,8 @@ module.exports = class Reader extends Component {
     this.clearComponent()
   }
   clearComponent() {
+    // Flag stream to stop
+    this.shouldStop = true
     // Remove all event listeners and variables
     if (this.timeout) {
       clearTimeout(this.timeout)
@@ -143,8 +145,9 @@ module.exports = class Reader extends Component {
     const isFirefox = /firefox/i.test(navigator.userAgent);
     const isSafari = !!navigator.userAgent.match(/Version\/[\d/]+.*Safari/);
 
+    let supported = {}
     if (navigator.mediaDevices && typeof navigator.mediaDevices.getSupportedConstraints === 'function') {
-      const supported = navigator.mediaDevices.getSupportedConstraints()
+      supported = navigator.mediaDevices.getSupportedConstraints()
     }
     const constraints = {}
 
@@ -171,6 +174,14 @@ module.exports = class Reader extends Component {
   handleVideo(stream) {
     const { preview } = this.els
     const { facingMode } = this.props
+
+    // Stop stream if we've been asked to
+    if (this.shouldStop) {
+      const streamTrackToStop = stream.getTracks()[0]
+      setTimeout(() => {
+        streamTrackToStop.stop();
+      }, 2000);
+    }
 
     // Preview element hasn't been rendered so wait for it.
     if (!preview) {


### PR DESCRIPTION
Clone of a PR that never made it to master on the parent repo ( https://github.com/JodusNodus/react-qr-reader/pull/113 )

There is a bug when you quickly load and unload the camera component, the camera will stay on even if the component got destroyed. 

This fix was tested on desktop and Android.

The code change touching `supported` was to make the package compilable under my version of node.

P.S. : You'll need to `gulp` to compile my code as I didn't want to submit compiled code with this PR..

Thanks !